### PR TITLE
Fix brackets in enabling ASB dead-letter queues config

### DIFF
--- a/doc/content/3.documentation/2.configuration/2.transports/3.azure-service-bus.md
+++ b/doc/content/3.documentation/2.configuration/2.transports/3.azure-service-bus.md
@@ -164,7 +164,7 @@ services.AddMassTransit(x =>
         {
             sb.ConfigureDeadLetterQueueDeadLetterTransport();
             sb.ConfigureDeadLetterQueueErrorTransport();
-        });
+        }
     });    
     
     x.UsingAzureServiceBus((context, cfg) =>


### PR DESCRIPTION
Small issue with the snippet having closing brackets that are unneeded as part of the 